### PR TITLE
make `pre {overflow-x: auto}` to avoid empty unscrollable scrollbars

### DIFF
--- a/app/assets/stylesheets/_about.css.scss
+++ b/app/assets/stylesheets/_about.css.scss
@@ -37,6 +37,6 @@
   }
 
   pre {
-    overflow-x: scroll;
+    overflow-x: auto;
   }
 }


### PR DESCRIPTION
![overflow-auto](https://cloud.githubusercontent.com/assets/9968388/8794623/9323a148-2f85-11e5-97d6-25525075ed08.jpg)
![overflow-scroll](https://cloud.githubusercontent.com/assets/9968388/8794624/9349b45a-2f85-11e5-8bff-afc951d0d550.jpg)
